### PR TITLE
Custom ransack attributes

### DIFF
--- a/lib/simple_form_ransack/form_proxy.rb
+++ b/lib/simple_form_ransack/form_proxy.rb
@@ -116,7 +116,7 @@ private
   end
 
   def real_name(name, opts)
-    predicates = Ransack::Configuration.preidcates.map(&:first).join("|")
+    predicates = Ransack::Configuration.predicates.map(&:first).join("|")
     match = name.to_s.match(/^(.+)_(#{predicates})$/)
     if match
       return match[1]

--- a/lib/simple_form_ransack/form_proxy.rb
+++ b/lib/simple_form_ransack/form_proxy.rb
@@ -116,7 +116,8 @@ private
   end
 
   def real_name(name, opts)
-    match = name.to_s.match(/^(.+)_(eq|cont|eq_any|gteq|lteq|gt|lt|start|end)$/)
+    predicates = Ransack::Configuration.preidcates.map(&:first).join("|")
+    match = name.to_s.match(/^(.+)_(#{predicates})$/)
     if match
       return match[1]
     else

--- a/lib/simple_form_ransack/form_proxy.rb
+++ b/lib/simple_form_ransack/form_proxy.rb
@@ -116,7 +116,8 @@ private
   end
 
   def real_name(name, opts)
-    predicates = Ransack::Configuration.predicates.map(&:first).join("|")
+    predicates = Ransack::Configuration.predicates.map(&:first).
+      map { |predicate| Regexp.escape(predicate) }.join("|")
     match = name.to_s.match(/^(.+)_(#{predicates})$/)
     if match
       return match[1]


### PR DESCRIPTION
I've changed the way simple_form_ransack builds the regexp for form helpers. Now it reads it from the Ransack configuration, which means that also custom predicates are supported. This is useful e.g. for cases such as this one: https://github.com/activerecord-hackery/ransack/issues/321